### PR TITLE
Camera Bobbing Script Added. Test Scene Included

### DIFF
--- a/Assets/CameraBobbing_Scene.unity
+++ b/Assets/CameraBobbing_Scene.unity
@@ -1,0 +1,446 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 2100000, guid: 6e582066299269740a0d0402c87b9731, type: 2}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &248718949
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 248718952}
+  - component: {fileID: 248718951}
+  - component: {fileID: 248718950}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &248718950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 248718949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &248718951
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 248718949}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &248718952
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 248718949}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &682685911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 682685915}
+  - component: {fileID: 682685914}
+  - component: {fileID: 682685913}
+  - component: {fileID: 682685912}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &682685912
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682685911}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &682685913
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682685911}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7a939697fa177a841afc1be5c00327c3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &682685914
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682685911}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &682685915
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682685911}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1353098970
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 373763985802475753, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4696392301619895344, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4696392301619895344, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1924713786}
+  m_SourcePrefab: {fileID: 100100000, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+--- !u!1 &1924713777 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4696392301619895344, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+  m_PrefabInstance: {fileID: 1353098970}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1924713781 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 7835228457182786434, guid: 7e297bf350bdd4dc99f6897f7f5b36df, type: 3}
+  m_PrefabInstance: {fileID: 1353098970}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1924713786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1924713777}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebcb601a4dfc5114cb3553ed902a8d9b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  movementInput: {x: 0, y: 0}
+  lookInput: {x: 0, y: 0}
+  sprintInput: 0
+  crouchInput: 0
+  rb: {fileID: 1924713781}
+  jumpForce: 5
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 248718952}
+  - {fileID: 1353098970}
+  - {fileID: 682685915}

--- a/Assets/CameraBobbing_Scene.unity.meta
+++ b/Assets/CameraBobbing_Scene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4ea1aed4d382b3140b68395495d0d7b6
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/CameraBobbing.cs
+++ b/Assets/Scripts/Player/CameraBobbing.cs
@@ -1,0 +1,133 @@
+using TMPro;
+using UnityEngine;
+
+// place this script on an empty gameobject with the main camera as a child
+
+// When walking along a surface, expect the transform to bob up and down.
+// The strength of the bobbing is determined by speed.
+// Sway is like bobbing but its horizontal only.
+// When airborne, bobbing will pause updating based on vertical speed.
+public class CameraBobbing : MonoBehaviour
+{
+    [Header("Toggles")]
+    [SerializeField] public bool enableBobbing = true;
+
+    #region Attributes for Bobbing
+    [Header("//// Bob Attributes /////")]
+    [Tooltip("The curve that the bob follows when walking. You could emulate a sin curve on this if you wanted to.")]
+    [SerializeField] private AnimationCurve bobWalkingPattern;
+    [Tooltip("How fast the bob will update to where it should be placed.")]
+    [SerializeField] private float bobUpdateSpeed = 75.0f;
+
+    [Header("Bob Period")]
+    [Tooltip("Bob Period when moving beyond max speed.")]
+    [SerializeField] private float bobPeriodRealMax = 0.2f;
+    [Tooltip("Bob Period when moving at max speed. Higher value = slow bob")]
+    [SerializeField] private float bobPeriodMax = 0.3f;
+    [Tooltip("Bob Period when moving at zero speed.")]
+    [SerializeField] private float bobPeriodMin = 0.7f;
+
+    [Tooltip("Whatever the period of bob is, take that divided by this divisor to get the sway period")]
+    [SerializeField] private float swayPeriodDivisor = 4f;
+
+    [Header("Bob Amplitude")]
+    [Tooltip("Bob Amplitude when moving at max speed. Higher value = higher bob")]
+    [SerializeField] private float bobWalkingAmplitude = 0.1f;
+    [Tooltip("How far the camera swings left to right")]
+    [SerializeField] private float swayWalkingAmplitude = 0.2f;
+
+    [Header("Bob Speed Detection Attributes")]
+    [Tooltip("Speed needed to reach the max bob period")]
+    [SerializeField] private float rigidBodyMaxSpeed = 10f;
+
+    [Tooltip("Value after rigidbodyMaxSpeed needed to reach PeriodRealMax. This value is added onto rigidBodyMaxSpeed.")]
+    [SerializeField] private float rigidBodySpeedOverflowSpeed = 5f; // DOES NOT NEED TO BE GREATER THAN RIGIDBODY MAX SPEED.
+
+    [Header("//// Airborne Attributes ////")]
+    [Tooltip("If the rigid body's vertical speed is greater than this, then bobbing will no longer apply")]
+    [SerializeField] private float airborneSpeedCutoff = 0.2f;
+    #endregion
+
+    // important variables
+    private float bobTimer = 0.0f;
+    private float targetBobPositionY = 0;
+    private float targetBobPositionX = 0;
+    private Rigidbody playerRigidbody;
+
+    #region Start and Update Methods
+    private void Start()
+    {
+        PlayerID playerID = FindFirstObjectByType<PlayerID>();
+        playerRigidbody = playerID.rb;
+    }
+    private void Update()
+    {
+        float verticalSpeed = GetVerticalSpeed();
+        if (verticalSpeed >= airborneSpeedCutoff) {
+            targetBobPositionX = targetBobPositionY = 0;
+        } else {
+            GroundedBobbingUpdate();
+        }
+        UpdateBobPosition();
+    }
+    #endregion
+
+    #region Bobbing Methods
+    // UpdateBobPosition() interpolates transform's local position to match
+    private void UpdateBobPosition() {
+        Vector3 targetBobPosition = new Vector3(targetBobPositionX, targetBobPositionY, 0f);
+        transform.localPosition = Vector3.Lerp(transform.localPosition, targetBobPosition, Time.deltaTime * bobUpdateSpeed);
+    }
+
+    // GroundedBobbingUpdate() Call when "grounded". Sets the target bob position to incorperate basic bobbing and swaying based on rigidbody velocity
+    private void GroundedBobbingUpdate() { 
+        // get speed values and stuff
+        float horizontalSpeed = GetHorizontalSpeed();
+        float horizontalSpeedPrecentage = horizontalSpeed / rigidBodyMaxSpeed;
+        float horizontalSpeedPrecentageClamped = Mathf.Clamp(horizontalSpeedPrecentage, 0f, 1f);
+
+        // get bob amplitude
+        float bobAmplitude = bobWalkingAmplitude * horizontalSpeedPrecentageClamped;
+
+        // get bob period
+        float bobPeriod = bobPeriodMax;
+        if (horizontalSpeedPrecentage > 1.0f) { // when going beyond max speed
+            float overflowHorizontalSpeedPrecentage = Mathf.Min(0, (horizontalSpeed - rigidBodyMaxSpeed) / rigidBodySpeedOverflowSpeed);
+            bobPeriod = (bobPeriodRealMax - bobPeriodMax) * overflowHorizontalSpeedPrecentage + bobPeriodMax;
+        } else { // when going under max speed
+            bobPeriod = (bobPeriodMax - bobPeriodMin) * horizontalSpeedPrecentageClamped + bobPeriodMin;
+        }
+
+        bobTimer += Time.deltaTime / bobPeriod;
+
+        // get sway amplitude
+        float swayAmplitude = swayWalkingAmplitude * horizontalSpeedPrecentageClamped;
+
+        // putting it all together
+        float bobTimeEvaluated = bobWalkingPattern.Evaluate(bobTimer % 1);
+        float targetAmplitude = bobAmplitude * bobTimeEvaluated;
+
+        float swayTimeEvaluated = Mathf.Sin(((bobTimer / swayPeriodDivisor) % 1) * (2 * Mathf.PI));
+        float targetSwayAmpltitude = swayAmplitude * swayTimeEvaluated;
+
+        // set target bob positions
+        targetBobPositionX = targetSwayAmpltitude;
+        targetBobPositionY = targetAmplitude;
+
+        // reset bob timer if I haven't bobbed in awhile
+        if (horizontalSpeed <= 0.001f) {
+            bobTimer = 0f;
+        }
+    }
+    #endregion
+
+    #region Helper Functions
+    // speed functions for vertical and horizontal speeds
+    private float GetHorizontalSpeed() {
+        return (new Vector3(playerRigidbody.linearVelocity.x, 0, playerRigidbody.linearVelocity.z)).magnitude;
+    }
+    private float GetVerticalSpeed() {
+        return playerRigidbody.linearVelocity.y;
+    }
+    #endregion
+}

--- a/Assets/Scripts/Player/CameraBobbing.cs.meta
+++ b/Assets/Scripts/Player/CameraBobbing.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c4fc51b11426bd42b20444e52138ccf


### PR DESCRIPTION
Added a script that adds camera bobbing to a gameobject that is the parent of the camera, the camera holder. Most of the attributes are already set in the script but there's an example attribute for the animation curve in the test scene included. I just realized this but the test scene will definitely have blank materials so be aware of that.