### PR TITLE
Deathbox Prefab   ////   (also patched respawning and playerhands)

### DIFF
--- a/Assets/Prefabs/World/WorldDeathbox.prefab
+++ b/Assets/Prefabs/World/WorldDeathbox.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6545723547028938944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1193115896798612653}
+  - component: {fileID: 6241987822881178409}
+  - component: {fileID: 2101240009022047563}
+  m_Layer: 0
+  m_Name: WorldDeathbox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1193115896798612653
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6545723547028938944}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &6241987822881178409
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6545723547028938944}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2000, y: 50, z: 2000}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2101240009022047563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6545723547028938944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd5699d36a9c6a44a62c6c4abba86b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mobLayer:
+    serializedVersion: 2
+    m_Bits: 512

--- a/Assets/Prefabs/World/WorldDeathbox.prefab.meta
+++ b/Assets/Prefabs/World/WorldDeathbox.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: df55d152ca411154ca63c1bdceac719c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerHands.cs
+++ b/Assets/Scripts/Player/PlayerHands.cs
@@ -82,11 +82,11 @@ public class PlayerHands : MonoBehaviour
 
     void Start()
     {
-        SetOverrideController();
-
         // retrieve essential objects
         UpdateClimbScript();
         UpdateHandAnimator();
+
+        SetOverrideController();
 
         // show the hands
         ToggleLeftArm(CONFIG_ShowLeftHand);

--- a/Assets/Scripts/Player/Respawn & Grave/ManageRespawn.cs
+++ b/Assets/Scripts/Player/Respawn & Grave/ManageRespawn.cs
@@ -37,6 +37,7 @@ public class ManageRespawn : MonoBehaviour
         Debug.Log("Respawing player");
         Time.timeScale = 1f;
         player.transform.position = respawnPoint;
+        player.GetComponent<Rigidbody>().linearVelocity = Vector3.zero;
         health.ResetHealth();
         hunger.ResetHunger();
         stamina.ResetStamina();

--- a/Assets/Scripts/World/DeathboxScript.cs
+++ b/Assets/Scripts/World/DeathboxScript.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+/// <summary>
+/// To use this script, attach it to an empty gameobject with a really large box collider.
+/// Anything that can collide with this box's layer will be killed if it is has a entity health manager.
+/// </summary>
+
+[RequireComponent(typeof(BoxCollider))]
+public class DeathboxScript : MonoBehaviour
+{
+    [Header("Attributes")]
+    [SerializeField] private LayerMask mobLayer;
+
+
+    // creating the deathbox damage context.
+    private DamageContext deathboxDamageContext;
+    private void Start()
+    {
+        deathboxDamageContext = new DamageContext();
+        deathboxDamageContext.attacker = gameObject;
+        deathboxDamageContext.victim = gameObject;
+        deathboxDamageContext.amount = 9999;
+        deathboxDamageContext.xxtraContext = "Deathbox";
+
+        gameObject.GetComponent<BoxCollider>().isTrigger = true;
+    }
+
+    // collision detection for deathbox
+    private void OnTriggerEnter(Collider other)
+    {
+        // see if theres a way to kill this entity.
+        EntityHealthManager healthManager = other.gameObject.GetComponent<EntityHealthManager>();
+        bool kill_entity = true;
+
+        // If a navmesh-agent based mob has fallen off the map, teleport them to the nearest navmesh point.
+
+        if ((mobLayer & (1 << other.gameObject.layer)) != 0) {
+            NavMeshAgent mobAgent = other.gameObject.GetComponent<NavMeshAgent>();
+
+            if (mobAgent != null) {
+                /// this is a mob, attempt to move them back onto the nav mesh instead of ending them. If successful, don't kill the mob.
+                NavMeshHit hit;
+                if (NavMesh.SamplePosition(other.gameObject.transform.position, out hit, Mathf.Infinity, NavMesh.AllAreas)) {
+                    Vector3 closestPoint = hit.position;
+
+                    mobAgent.Warp(closestPoint);
+
+                    kill_entity = false;
+                }
+            }
+        }
+
+
+        // unless otherwise, if the fallen object has a healthManager, kill it.
+        if (healthManager != null) {
+            if (kill_entity == true) {
+                deathboxDamageContext.victim = other.gameObject;
+                healthManager.Die(deathboxDamageContext);
+            }
+        }
+        // you could add something here to destroy non-entity objects, but I didn't because it could screw over someone else.
+    }
+}

--- a/Assets/Scripts/World/DeathboxScript.cs.meta
+++ b/Assets/Scripts/World/DeathboxScript.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bd5699d36a9c6a44a62c6c4abba86b5


### PR DESCRIPTION
NEW: Added DeathboxScript which recieves touch triggers from a boxcollider and kills entities that touch it or teleports mobs to the nearest navmesh. It is unable to kill mobs defined by the mob layermask. The prefab needs to be added in and it is under assets/prefabs/world/.

BUGFIX: Respawning now resets player velocity, preventing players from dying again due to fall damage after respawning.
BUGFIX: i moved one line in playerhands so it no longer throws a null reference error.